### PR TITLE
Basic DML DDL tests

### DIFF
--- a/TestApplications/NTDLS.Katzebase.UnitTests/NTDLS.Katzebase.UnitTests.fsproj
+++ b/TestApplications/NTDLS.Katzebase.UnitTests/NTDLS.Katzebase.UnitTests.fsproj
@@ -36,8 +36,11 @@
 		
         <Compile Include="Scripts/Engine/DDLExecution/BasicTest.DDLExecution.ver.0.0.1.fsx">
 			<Link>Unit/Engine/Execution/DDL/BasicTest.DDLExecution.fsx</Link>
+		</Compile>
+
+		<Compile Include="Scripts/Engine/DMLExecution/BasicTest.DMLExecution.ver.0.0.1.fsx">
+			<Link>Unit/Engine/Execution/DML/BasicTest.DMLExecution.fsx</Link>
 		</Compile>		
-		
 		
 		<Compile Include="Program.ver.0.0.1.fsx">
 			<Link>Program.fsx</Link>
@@ -64,7 +67,7 @@
     <PackageReference Include="protobuf-net" Version="3.2.30" />
     <PackageReference Include="protobuf-net.Core" Version="3.2.30" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="xunit" Version="2.9.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.30">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TestApplications/NTDLS.Katzebase.UnitTests/Program.ver.0.0.1.fsx
+++ b/TestApplications/NTDLS.Katzebase.UnitTests/Program.ver.0.0.1.fsx
@@ -4,9 +4,12 @@ open Shared
 open BasicTest.Parser.ver.``0``.``0``.``1``
 open BasicTest.IO.ver.``0``.``0``.``1``.IOTests
 open BasicTest.DDLExecution.ver.``0``.``0``.``1``
+open BasicTest.DMLExecution.ver.``0``.``0``.``1``
 
 module KatzebaseTests =
+    //if false then
     ParserBasicTests.``Parse "SELECT * FROM MASTER:ACCOUNT"`` None 
     ParserBasicTests.``[Condition] Parse "SELECT * FROM MASTER:ACCOUNT WHERE Username = ?Username AND PasswordHash = ?PasswordHash"`` None
     DDLExecutionBasicTests.``Execute "CREATE SCHEMA testSch"`` None
+    DMLExecutionBasicTests.``Execute "INSERT INTO testSch (COL1, COL2) VALUES (1,2), ("A", "B")"`` None
     printfn "Done!"        

--- a/TestApplications/NTDLS.Katzebase.UnitTests/Scripts/Engine/DDLExecution/BasicTest.DDLExecution.ver.0.0.1.fsx
+++ b/TestApplications/NTDLS.Katzebase.UnitTests/Scripts/Engine/DDLExecution/BasicTest.DDLExecution.ver.0.0.1.fsx
@@ -15,29 +15,71 @@ open System.Collections.Generic
 
 module DDLExecutionBasicTests =
     open NTDLS.Katzebase.Engine.Parsers
-    open NTDLS.Katzebase.Engine.Parsers.Query.Fields
-    open NTDLS.Katzebase.Client
+    
+    open NTDLS.Katzebase.Client.Payloads
     open NTDLS.Katzebase.Client.Types
-    open NTDLS.Katzebase.Client.Exceptions
-    open NTDLS.Katzebase.Engine.Library
 
     type SingleCount () =
-        member val Count = 0 with get, set
+        let mutable c = 0
+        member this.Count 
+            with get() = c
+            and set(v) = c <- v
 
     let ``Execute "CREATE SCHEMA testSch"`` (outputOpt:ITestOutputHelper option) =
+        let testSchema = "testSchDDL"
         let preLogin = _core.Sessions.CreateSession(Guid.NewGuid(), "testUser", "testClient")
-        _core.Query.ExecuteNonQuery(preLogin, "DROP SCHEMA testSch")
-        _core.Query.ExecuteNonQuery(preLogin, "CREATE SCHEMA testSch")
-        _core.Query.ExecuteNonQuery(preLogin, "insert into testSch (\r\nid = 123, value = '456'\r\n)");
-        let cnt = _core.Query.ExecuteQuery<SingleCount>(preLogin, "SELECT COUNT(*) FROM testSch", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
-        equals 1 (cnt |> Seq.item 0).Count
-        //_core.Query.ExecuteQuery<int>(preLogin, "SELECT COUNT(*) FROM MASTER:ACCOUNT", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+        try
+            _core.Query.ExecuteNonQuery(preLogin, $"DROP SCHEMA {testSchema}")
+        with
+        | exn ->
+            ()
+        _core.Query.ExecuteNonQuery(preLogin, $"CREATE SCHEMA {testSchema}")
+        _core.Query.ExecuteNonQuery(preLogin, $"insert into {testSchema} (\r\nid = 123, value = '456'\r\n)")
+        _core.Query.ExecuteNonQuery(preLogin, $"insert into {testSchema} (\r\nid = 321, value = '654'\r\n)")
+        _core.Transactions.Commit(preLogin)
+        //let cnt = _core.Query.ExecuteQuery<SingleCount>(preLogin, "SELECT COUNT(*) FROM testSch", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+        //equals 1 (cnt |> Seq.item 0).Count
+        let userParameters = new KbInsensitiveDictionary<KbConstant>()
 
-    //type CommonTests (output:ITestOutputHelper) =
-    //    [<Fact>]
-    //    member this.``Parse "SELECT * FROM MASTER:ACCOUNT"`` () =
-    //        ``Parse "SELECT * FROM MASTER:ACCOUNT"`` (Some output)
 
-    //    [<Fact>]
-    //    member this.``[Condition] Parse "SELECT * FROM MASTER:ACCOUNT WHERE Username = ¢IUsername AND PasswordHash = ¢IPasswordHash"`` () =
-    //        ``[Condition] Parse "SELECT * FROM MASTER:ACCOUNT WHERE Username = ¢IUsername AND PasswordHash = ¢IPasswordHash"`` (Some output)
+        let countTest sql expectedCount = 
+            try
+                let preparedQueries = StaticQueryParser.ParseBatch(_core, sql, userParameters)
+                let preparedQuery = preparedQueries.Item 0
+        
+                let queryResultCollection = _core.Query.ExecuteQuery(preLogin, preparedQuery)
+                equals 1 queryResultCollection.Collection.Count
+
+                let queryDocList = ((queryResultCollection.Collection.Item 0) :?> KbQueryDocumentListResult).Rows
+                equals 1 queryDocList.Count
+                equals $"{expectedCount}" queryDocList[0].Values[0]
+
+                let sc =
+                    _core.Query.ExecuteQuery<SingleCount>(preLogin, sql, Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+                    |> Seq.toArray
+                    |> Array.item 0
+
+                equals expectedCount sc.Count
+            with
+            | exn ->
+                testPrint outputOpt "[By design] %s" exn.InnerException.InnerException.Message
+                equals "Value should not be null. (Parameter 'textValue')" exn.InnerException.InnerException.Message
+
+        testPrint outputOpt "count scalar"
+        countTest $"SELECT COUNT(1) as Count FROM {testSchema}" 2
+
+        testPrint outputOpt "count star"
+        countTest $"SELECT COUNT(*) as Count FROM {testSchema}" 2
+
+        testPrint outputOpt "count column id"
+        countTest $"SELECT COUNT(id) as Count FROM {testSchema}" 2
+
+        testPrint outputOpt "count column not existed"
+        countTest $"SELECT COUNT(not_existed_column) as Count FROM {testSchema}" 2
+
+
+    type CommonTests (output:ITestOutputHelper) =
+        [<Fact>]
+        member this.``Execute "CREATE SCHEMA testSch"`` () =
+            ``Execute "CREATE SCHEMA testSch"`` (Some output)
+

--- a/TestApplications/NTDLS.Katzebase.UnitTests/Scripts/Engine/DMLExecution/BasicTest.DMLExecution.ver.0.0.1.fsx
+++ b/TestApplications/NTDLS.Katzebase.UnitTests/Scripts/Engine/DMLExecution/BasicTest.DMLExecution.ver.0.0.1.fsx
@@ -103,7 +103,7 @@ module DMLExecutionBasicTests =
 
         
         let rString = 
-            _core.Query.ExecuteQuery<TwoColumnString>(preLogin, $"SELECT * FROM {testSchema}", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+            _core.Query.ExecuteQuery<TwoColumnString>(preLogin, $"SELECT * FROM {testSchema} ORDER BY COL1", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
             |> Seq.toArray
 
         equals 2 rString.Length

--- a/TestApplications/NTDLS.Katzebase.UnitTests/Scripts/Engine/DMLExecution/BasicTest.DMLExecution.ver.0.0.1.fsx
+++ b/TestApplications/NTDLS.Katzebase.UnitTests/Scripts/Engine/DMLExecution/BasicTest.DMLExecution.ver.0.0.1.fsx
@@ -1,0 +1,140 @@
+#if INTERACTIVE
+#load "../../UnitTestsSharedResource.ver.0.0.1.fsx"
+#load "../../Tests.ver.0.0.1.fsx"
+#r "nuget: DecimalMath.DecimalEx, 1.0.2"
+#r "nuget: Xunit"
+#r "nuget: NCalc"
+#endif
+
+open Shared
+open Tests
+open Xunit
+open Xunit.Abstractions
+open System
+open System.Collections.Generic
+
+module DMLExecutionBasicTests =
+    open NTDLS.Katzebase.Engine.Parsers
+    open NTDLS.Katzebase.Engine.Parsers.Query    
+    open NTDLS.Katzebase.Engine.Parsers.Query.Fields    
+    open NTDLS.Katzebase.Client.Types
+    open NTDLS.Katzebase.Engine.QueryProcessing
+
+    type ExprProc = StaticScalerExpressionProcessor
+
+    type TwoColumnString () =
+        member val COL1 = "" with get, set
+        member val COL2 = "" with get, set
+
+    type TwoColumnInt () =
+        member val COL1 = 0 with get, set
+        member val COL2 = 0 with get, set
+
+    type TwoColumnDouble () =
+        member val COL1 = 0.0 with get, set
+        member val COL2 = 0.0 with get, set
+    let testSchema = $"testSchDML"
+    let plainInsert = $"""INSERT INTO {testSchema} (COL1, COL2) VALUES (1,2), ("A", "B")"""
+
+    let ``Execute "INSERT INTO testSch (COL1, COL2) VALUES (1,2), ("A", "B")"`` (outputOpt:ITestOutputHelper option) =
+        let preLogin = _core.Sessions.CreateSession(Guid.NewGuid(), "testUser", "testClient")
+        try
+            _core.Query.ExecuteNonQuery(preLogin, $"DROP SCHEMA {testSchema}")
+        with
+        | exn ->
+            ()
+        _core.Query.ExecuteNonQuery(preLogin, $"CREATE SCHEMA {testSchema}")
+
+        let userParameters = new KbInsensitiveDictionary<KbConstant>()
+        let preparedQueries = StaticQueryParser.ParseBatch(_core, plainInsert, userParameters)
+        let preparedQuery = preparedQueries.Item 0
+        
+        equals [|"COL1"; "COL2"|] (preparedQuery.InsertFieldNames |> Seq.toArray)
+        equals 2 preparedQuery.InsertFieldValues.Count
+
+        let insert0 = preparedQuery.InsertFieldValues.Item 0
+        let insert1 = preparedQuery.InsertFieldValues.Item 1
+
+        equals 2 insert0.Count
+        equals 2 insert1.Count
+
+        let i0v0 = insert0.Item 0
+        let i0v1 = insert0.Item 1
+        let i1v0 = insert1.Item 0
+        let i1v1 = insert1.Item 1
+
+        match i0v0.Expression with
+        | :? Fields.QueryFieldConstantNumeric as num -> 
+            equals "$n_2$" num.Value
+
+        match i0v1.Expression with
+        | :? Fields.QueryFieldConstantNumeric as num -> 
+            equals "$n_3$" num.Value
+
+        match i1v0.Expression with
+        | :? Fields.QueryFieldConstantString as str -> 
+            equals "$s_0$" str.Value
+
+        match i1v1.Expression with
+        | :? Fields.QueryFieldConstantString as str -> 
+            equals "$s_1$" str.Value
+           
+        let transactionReference = _core.Transactions.Acquire(preLogin)
+        let fieldQueryCollection = QueryFieldCollection (preparedQuery.Batch)
+        let auxiliaryFields = KbInsensitiveDictionary<string> ()
+        let collapsed01 = 
+            ExprProc.CollapseScalerQueryField(
+                i0v1.Expression
+                , transactionReference.Transaction
+                , preparedQuery, fieldQueryCollection
+                , auxiliaryFields)
+        let collapsed11 = 
+            ExprProc.CollapseScalerQueryField(
+                i1v1.Expression
+                , transactionReference.Transaction
+                , preparedQuery, fieldQueryCollection
+                , auxiliaryFields)
+
+        equals "2" collapsed01
+        equals "B" collapsed11
+
+        let queryResultCollection = _core.Query.ExecuteQuery(preLogin, preparedQuery)
+        _core.Transactions.Commit(preLogin)
+
+        
+        let rString = 
+            _core.Query.ExecuteQuery<TwoColumnString>(preLogin, $"SELECT * FROM {testSchema}", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+            |> Seq.toArray
+
+        equals 2 rString.Length
+        equals "1" rString[0].COL1
+        equals "B" rString[1].COL2
+
+        let rInt = 
+            _core.Query.ExecuteQuery<TwoColumnInt>(preLogin, $"SELECT * FROM {testSchema} where COL1 = 1", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+            |> Seq.toArray
+
+        equals 1 rInt.Length
+        equals 1 rInt[0].COL1
+
+        let rDouble = 
+            _core.Query.ExecuteQuery<TwoColumnDouble>(preLogin, $"SELECT * FROM {testSchema} where COL1 = 1", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+            |> Seq.toArray
+
+        equals 1 rDouble.Length
+        equals 1.0 rDouble[0].COL1
+
+        try
+            let rDouble = 
+                _core.Query.ExecuteQuery<TwoColumnDouble>(preLogin, $"SELECT * FROM {testSchema}", Unchecked.defaultof<KbInsensitiveDictionary<string>>)
+                |> Seq.toArray
+
+            ()
+        with
+        | exn ->
+            equals "The input string 'A' was not in a correct format." exn.Message
+
+    type CommonTests (output:ITestOutputHelper) =
+        [<Fact>]
+        member this.``Execute "INSERT INTO testSch (COL1, COL2) VALUES (1,2), ("A", "B")"`` () =
+            ``Execute "INSERT INTO testSch (COL1, COL2) VALUES (1,2), ("A", "B")"`` (Some output)


### PR DESCRIPTION
Hi @NTDLS ,

I found that if the tests are sequentially executed (F5 execute) then everything goes fine. But if we use test explorer paralleled executed, then dead lock occurred. Would you mind take a look? (run the tests in Test Explorer)

Run NTDLS.Katzebase.UnitTests.exe or F5 execute
![image](https://github.com/user-attachments/assets/af551db1-a72b-4fa2-a8d5-50397f6f54cb)

Test explorer
![image](https://github.com/user-attachments/assets/a8557cef-1a74-4ad1-9aa8-c5878198d3c6)

However even in DML test, the test schema testSchDML had not yet been created... weird...

